### PR TITLE
fix(auth): reject Anthropic OAuth tokens early with clear error messages

### DIFF
--- a/crates/proto/src/lib.rs
+++ b/crates/proto/src/lib.rs
@@ -18,3 +18,13 @@ pub use event::{
 pub use message::{AgentMessage, ChannelId, Role, SessionId};
 /// Re-export of tool call definition and result types.
 pub use tool::{ToolCall, ToolDefinition, ToolResult};
+
+/// Returns `true` when the key looks like an Anthropic OAuth access token
+/// (`sk-ant-oat*`) rather than a permanent API key (`sk-ant-api*`).
+///
+/// Anthropic's Messages API does not accept OAuth tokens — only permanent
+/// API keys sent via the `x-api-key` header. This helper is used across
+/// crates to reject OAuth tokens early with a clear error message.
+pub fn is_anthropic_oauth_token(key: &str) -> bool {
+    key.starts_with("sk-ant-oat")
+}


### PR DESCRIPTION
## Summary

- Consolidate `is_anthropic_oauth_token()` helper to `proto` crate for shared use
- Reject OAuth tokens (`sk-ant-oat*`) at provider level in `anthropic.rs` with clear error
- Reject OAuth tokens in model catalog fetch in `model_catalog.rs`  
- Remove 2 silent OAuth fallbacks in `event.rs` — propagate errors to user instead
- Improve `create_anthropic_api_key()` error reporting (read response body before checking status)

## Why

Anthropic's Messages API does not support OAuth tokens for direct API calls. Previously, the code silently fell back to storing raw OAuth tokens, which then failed at API call time with cryptic errors. Now tokens are rejected early with actionable user-facing messages directing to the API Key authentication method.

## Verification

- `cargo fmt --all -- --check` ✅
- `cargo clippy --workspace -- -D warnings` ✅  
- `cargo test --workspace --lib --bins` — **327/327 passed** ✅
- 5 files changed, 75 insertions, 76 deletions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Anthropic OAuth tokens are now rejected early with clear guidance directing users to use API keys instead.
  * Enhanced error reporting when creating Anthropic API keys, providing HTTP status and response details for troubleshooting.
  * Consolidated OAuth token validation across the codebase for consistent authentication behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->