### PR TITLE
fix(auth): use Bearer auth for Anthropic OAuth tokens

### DIFF
--- a/crates/cli/src/model_catalog.rs
+++ b/crates/cli/src/model_catalog.rs
@@ -494,14 +494,10 @@ async fn fetch_anthropic_model_ids(api_key: &str) -> Result<Vec<String>, String>
     let mut req_builder = client.get(url).header("anthropic-version", "2023-06-01");
 
     if proto::is_anthropic_oauth_token(api_key) {
-        return Err(
-            "Anthropic OAuth tokens (sk-ant-oat*) cannot be used to list models. \
-             Use /login and select 'API Key' instead of OAuth, \
-             or set the openpista_API_KEY environment variable."
-                .to_string(),
-        );
+        req_builder = req_builder.bearer_auth(api_key);
+    } else {
+        req_builder = req_builder.header("x-api-key", api_key);
     }
-    req_builder = req_builder.header("x-api-key", api_key);
 
     let response = req_builder
         .send()
@@ -928,7 +924,7 @@ mod tests {
     }
 
     #[test]
-    fn oauth_token_is_rejected_by_shared_helper() {
+    fn oauth_token_detected_by_shared_helper() {
         assert!(proto::is_anthropic_oauth_token("sk-ant-oat01-abc123"));
         assert!(!proto::is_anthropic_oauth_token("sk-ant-api03-abc123"));
         assert!(!proto::is_anthropic_oauth_token(""));

--- a/crates/cli/src/tui/event.rs
+++ b/crates/cli/src/tui/event.rs
@@ -304,25 +304,7 @@ async fn build_and_store_credential_with_path(
                     .map_err(|e| e.to_string())?
                 };
 
-                let credential = if provider_name == "anthropic" {
-                    let permanent_key =
-                        crate::auth::create_anthropic_api_key(&oauth_credential.access_token)
-                            .await
-                            .map_err(|e| {
-                                format!(
-                                    "Failed to convert OAuth token to API key: {e}. \
-                                     Use /login and select 'API Key' instead of OAuth."
-                                )
-                            })?;
-                    crate::auth::ProviderCredential {
-                        access_token: permanent_key,
-                        refresh_token: None,
-                        expires_at: None,
-                        endpoint: None,
-                    }
-                } else {
-                    oauth_credential
-                };
+                let credential = oauth_credential;
 
                 (
                     credential,
@@ -730,27 +712,7 @@ pub async fn run_tui(
                                         crate::auth::complete_code_display_flow(&pending, &code)
                                             .await
                                             .map_err(|e| e.to_string())?;
-                                    let credential = if provider_name == "anthropic" {
-                                        let permanent_key =
-                                            crate::auth::create_anthropic_api_key(
-                                                &oauth_cred.access_token,
-                                            )
-                                            .await
-                                            .map_err(|e| {
-                                                format!(
-                                                    "Failed to convert OAuth token to API key: {e}. \
-                                                     Use /login and select 'API Key' instead of OAuth."
-                                                )
-                                            })?;
-                                        crate::auth::ProviderCredential {
-                                            access_token: permanent_key,
-                                            refresh_token: None,
-                                            expires_at: None,
-                                            endpoint: None,
-                                        }
-                                    } else {
-                                        oauth_cred
-                                    };
+                                    let credential = oauth_cred;
                                     let p = provider_name.clone();
                                     tokio::task::spawn_blocking(move || {
                                         persist_credential(p, credential, cred_path)

--- a/crates/proto/src/lib.rs
+++ b/crates/proto/src/lib.rs
@@ -22,9 +22,8 @@ pub use tool::{ToolCall, ToolDefinition, ToolResult};
 /// Returns `true` when the key looks like an Anthropic OAuth access token
 /// (`sk-ant-oat*`) rather than a permanent API key (`sk-ant-api*`).
 ///
-/// Anthropic's Messages API does not accept OAuth tokens — only permanent
-/// API keys sent via the `x-api-key` header. This helper is used across
-/// crates to reject OAuth tokens early with a clear error message.
+/// When `true`, callers should use `Authorization: Bearer` instead of
+/// `x-api-key` to authenticate with the Anthropic Messages API.
 pub fn is_anthropic_oauth_token(key: &str) -> bool {
     key.starts_with("sk-ant-oat")
 }


### PR DESCRIPTION
## Summary

- **Switch from rejecting to using** Anthropic OAuth tokens (`sk-ant-oat*`): use `Authorization: Bearer` header instead of erroring out, since the Anthropic Messages API supports OAuth tokens with `user:inference` scope.
- **Remove `create_anthropic_api_key()`** function from `auth.rs` (both prod and test stub) — it attempted to convert OAuth tokens to permanent API keys via a Claude CLI-specific endpoint that is unnecessary now.
- **Remove OAuth→API-key conversion** in `event.rs` (2 locations) — OAuth credentials are now used directly.
- **Update doc comments and test names** to reflect the new Bearer auth behavior.

## Changes

| File | Change |
|------|--------|
| `crates/agent/src/anthropic.rs` | OAuth token → `bearer_auth()`, API key → `x-api-key` |
| `crates/cli/src/model_catalog.rs` | Same Bearer/x-api-key branching |
| `crates/cli/src/tui/event.rs` | Remove 2 `create_anthropic_api_key()` call sites |
| `crates/cli/src/auth.rs` | Delete `create_anthropic_api_key()` function (prod + test stub) |
| `crates/proto/src/lib.rs` | Update `is_anthropic_oauth_token()` doc comment |

## Verification

- ✅ `cargo fmt --all -- --check` — clean
- ✅ `cargo clippy --workspace -- -D warnings` — 0 warnings
- ✅ `cargo test --workspace --lib --bins` — 327 tests passed

Net: **+12 lines, -112 lines** (100 lines removed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OAuth tokens are now supported for Anthropic API authentication. The system now uses bearer token authentication for OAuth credentials instead of requiring conversion to permanent API keys.

* **Bug Fixes**
  * Removed the legacy API key generation workflow that was previously required for OAuth token conversion. OAuth credentials are now used directly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->