### PR TITLE
fix(tui): use unicode display width for cursor positioning in Korean/…

### DIFF
--- a/crates/cli/src/tui/app.rs
+++ b/crates/cli/src/tui/app.rs
@@ -1,5 +1,6 @@
 //! TUI application state, rendering, and input handling.
 #![allow(dead_code)]
+use unicode_width::UnicodeWidthStr;
 
 use super::theme::THEME;
 use crate::auth_picker::{self, AuthLoginIntent, AuthMethodChoice, LoginBrowseStep};
@@ -1502,19 +1503,19 @@ impl TuiApp {
 
         match step {
             LoginBrowseStep::SelectProvider => {
-                let cursor_col = query.chars().count() as u16;
+                let cursor_col = UnicodeWidthStr::width(query.as_str()) as u16;
                 frame.set_cursor_position((chunks[1].x + 10 + cursor_col, chunks[1].y + 3));
             }
             LoginBrowseStep::InputEndpoint => {
-                let cursor_col = input_buffer.chars().count() as u16;
+                let cursor_col = UnicodeWidthStr::width(input_buffer.as_str()) as u16;
                 frame.set_cursor_position((chunks[1].x + 12 + cursor_col, chunks[1].y + 4));
             }
             LoginBrowseStep::InputApiKey => {
                 let is_code_display = matches!(selected_method, Some(AuthMethodChoice::OAuth));
                 let display_len = if is_code_display {
-                    input_buffer.chars().count()
+                    UnicodeWidthStr::width(input_buffer.as_str())
                 } else {
-                    masked_buffer.chars().count()
+                    UnicodeWidthStr::width(masked_buffer.as_str())
                 };
                 // " Code: " = 7, " API key: " = 10
                 let label_offset: u16 = if is_code_display { 8 } else { 11 };
@@ -1658,7 +1659,7 @@ impl TuiApp {
         );
 
         if *search_active {
-            let cursor_col = query.chars().count() as u16;
+            let cursor_col = UnicodeWidthStr::width(query.as_str()) as u16;
             frame.set_cursor_position((footer[0].x + 18 + cursor_col, footer[0].y));
         }
     }
@@ -1727,7 +1728,7 @@ impl TuiApp {
         frame.render_widget(input, area);
 
         if is_idle_or_prompting {
-            let cursor_col = self.input[..self.cursor_pos].chars().count() as u16;
+            let cursor_col = UnicodeWidthStr::width(&self.input[..self.cursor_pos]) as u16;
             frame.set_cursor_position((area.x + 1 + cursor_col, area.y + 1));
         }
 

--- a/crates/cli/src/tui/home.rs
+++ b/crates/cli/src/tui/home.rs
@@ -1,4 +1,5 @@
 //! Home/welcome screen widget — centered logo, input box, and keyboard shortcuts.
+use unicode_width::UnicodeWidthStr;
 
 use super::app::{AppState, TuiApp};
 use super::theme::THEME;
@@ -88,7 +89,7 @@ pub fn render(app: &TuiApp, frame: &mut Frame<'_>, area: Rect) {
 
     // Show cursor when idle
     if app.state == AppState::Idle {
-        let cursor_col = app.input[..app.cursor_pos].chars().count() as u16;
+        let cursor_col = UnicodeWidthStr::width(&app.input[..app.cursor_pos]) as u16;
         frame.set_cursor_position((inner_input_v[0].x + 1 + cursor_col, inner_input_v[0].y));
     }
 


### PR DESCRIPTION
…CJK input

Replace .chars().count() with UnicodeWidthStr::width() for all cursor column calculations. Korean/CJK characters occupy 2 terminal columns but were counted as 1, causing the cursor to drift behind the text and corrupting mid-text editing.

Fixed locations:
- render_input() main chat input box
- render() home screen input box
- render_login_browser() provider search, endpoint, API key inputs
- render_model_browser() search input

Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-opencode)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed cursor positioning and text display in the CLI terminal interface to properly handle wide characters across input fields and interactive elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->