### PR TITLE
fix: embed migrations at compile time and sanitize tool names for Anthropic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ serde_yaml = "0.9"
 async-openai = { version = "0.27", default-features = false, features = ["rustls"] }
 
 # 데이터베이스
-sqlx = { version = "0.8", default-features = false, features = ["runtime-tokio", "sqlite", "migrate"] }
+sqlx = { version = "0.8", default-features = false, features = ["runtime-tokio", "sqlite", "migrate", "macros"] }
 
 # CLI
 clap = { version = "4", features = ["derive"] }

--- a/crates/agent/src/memory.rs
+++ b/crates/agent/src/memory.rs
@@ -32,13 +32,7 @@ impl SqliteMemory {
             .await
             .map_err(|e| DatabaseError::Sqlx(e.to_string()))?;
 
-        let migrations_dir =
-            std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../../migrations");
-        let migrator = sqlx::migrate::Migrator::new(migrations_dir.as_path())
-            .await
-            .map_err(|e| DatabaseError::Migration(e.to_string()))?;
-
-        migrator
+        sqlx::migrate!("../../migrations")
             .run(&pool)
             .await
             .map_err(|e| DatabaseError::Migration(e.to_string()))?;

--- a/crates/tools/src/bash.rs
+++ b/crates/tools/src/bash.rs
@@ -52,7 +52,7 @@ impl Default for BashTool {
 #[async_trait]
 impl Tool for BashTool {
     fn name(&self) -> &str {
-        "system.run"
+        "system_run"
     }
 
     fn description(&self) -> &str {

--- a/crates/tools/src/browser.rs
+++ b/crates/tools/src/browser.rs
@@ -199,7 +199,7 @@ impl Default for BrowserScreenshotTool {
 #[async_trait]
 impl Tool for BrowserTool {
     fn name(&self) -> &str {
-        "browser.navigate"
+        "browser_navigate"
     }
 
     fn description(&self) -> &str {
@@ -299,7 +299,7 @@ impl Tool for BrowserTool {
 #[async_trait]
 impl Tool for BrowserClickTool {
     fn name(&self) -> &str {
-        "browser.click"
+        "browser_click"
     }
 
     fn description(&self) -> &str {
@@ -397,7 +397,7 @@ impl Tool for BrowserClickTool {
 #[async_trait]
 impl Tool for BrowserTypeTool {
     fn name(&self) -> &str {
-        "browser.type"
+        "browser_type"
     }
 
     fn description(&self) -> &str {
@@ -519,7 +519,7 @@ impl Tool for BrowserTypeTool {
 #[async_trait]
 impl Tool for BrowserScreenshotTool {
     fn name(&self) -> &str {
-        "browser.screenshot"
+        "browser_screenshot"
     }
 
     fn description(&self) -> &str {
@@ -623,7 +623,7 @@ mod tests {
     #[test]
     fn browser_click_tool_metadata_is_stable() {
         let tool = BrowserClickTool::new();
-        assert_eq!(tool.name(), "browser.click");
+        assert_eq!(tool.name(), "browser_click");
         assert!(tool.description().contains("Click"));
 
         let schema = tool.parameters_schema();
@@ -634,7 +634,7 @@ mod tests {
     #[test]
     fn browser_type_tool_metadata_is_stable() {
         let tool = BrowserTypeTool::new();
-        assert_eq!(tool.name(), "browser.type");
+        assert_eq!(tool.name(), "browser_type");
         assert!(tool.description().contains("Type"));
 
         let schema = tool.parameters_schema();
@@ -646,7 +646,7 @@ mod tests {
     #[test]
     fn browser_screenshot_tool_metadata_is_stable() {
         let tool = BrowserScreenshotTool::new();
-        assert_eq!(tool.name(), "browser.screenshot");
+        assert_eq!(tool.name(), "browser_screenshot");
         assert!(tool.description().contains("screenshot"));
 
         let schema = tool.parameters_schema();
@@ -684,7 +684,7 @@ mod tests {
             .execute("call-2", serde_json::json!({"selector":7}))
             .await;
         assert_eq!(result.call_id, "call-2");
-        assert_eq!(result.tool_name, "browser.click");
+        assert_eq!(result.tool_name, "browser_click");
         assert!(result.is_error);
         assert!(result.output.contains("Invalid arguments"));
     }
@@ -696,7 +696,7 @@ mod tests {
             .execute("call-3", serde_json::json!({"selector":"#q"}))
             .await;
         assert_eq!(result.call_id, "call-3");
-        assert_eq!(result.tool_name, "browser.type");
+        assert_eq!(result.tool_name, "browser_type");
         assert!(result.is_error);
         assert!(result.output.contains("Invalid arguments"));
     }
@@ -708,7 +708,7 @@ mod tests {
             .execute("call-4", serde_json::json!({"full_page":"yes"}))
             .await;
         assert_eq!(result.call_id, "call-4");
-        assert_eq!(result.tool_name, "browser.screenshot");
+        assert_eq!(result.tool_name, "browser_screenshot");
         assert!(result.is_error);
         assert!(result.output.contains("Invalid arguments"));
     }
@@ -739,7 +739,7 @@ mod tests {
             )
             .await;
         assert_eq!(result.call_id, "call-6");
-        assert_eq!(result.tool_name, "browser.click");
+        assert_eq!(result.tool_name, "browser_click");
         assert!(!result.output.is_empty());
     }
 
@@ -753,7 +753,7 @@ mod tests {
             )
             .await;
         assert_eq!(result.call_id, "call-7");
-        assert_eq!(result.tool_name, "browser.type");
+        assert_eq!(result.tool_name, "browser_type");
         assert!(!result.output.is_empty());
     }
 
@@ -767,7 +767,7 @@ mod tests {
             )
             .await;
         assert_eq!(result.call_id, "call-8");
-        assert_eq!(result.tool_name, "browser.screenshot");
+        assert_eq!(result.tool_name, "browser_screenshot");
         assert!(!result.output.is_empty());
     }
 

--- a/crates/tools/src/container.rs
+++ b/crates/tools/src/container.rs
@@ -106,7 +106,7 @@ impl Default for ContainerTool {
 #[async_trait]
 impl Tool for ContainerTool {
     fn name(&self) -> &str {
-        "container.run"
+        "container_run"
     }
 
     fn description(&self) -> &str {

--- a/crates/tools/src/screen.rs
+++ b/crates/tools/src/screen.rs
@@ -39,7 +39,7 @@ impl Default for ScreenTool {
 #[async_trait]
 impl Tool for ScreenTool {
     fn name(&self) -> &str {
-        "screen.capture"
+        "screen_capture"
     }
 
     fn description(&self) -> &str {


### PR DESCRIPTION
## Problem

Two bugs that prevent openpista from working after installation:

### 1. Migration error on installed binary
```
Error: DB error: Migration error: while resolving migrations: No such file or directory (os error 2)
```
`memory.rs` used `env!("CARGO_MANIFEST_DIR")` to resolve the migrations path at runtime, which is hardcoded to the build machine's directory. On any other machine, the path doesn't exist.

### 2. Tool name validation error with Anthropic models
```
Error: LLM error: APIError: anthropic error: tools.0.custom.name: String should match pattern '^[a-zA-Z0-9_-]{1,128}$'
```
Tool names like `system.run`, `browser.navigate`, `browser.click`, `browser.type`, `browser.screenshot`, `container.run`, and `screen.capture` contain dots, which Anthropic's API rejects.

## Fix

- Replace `Migrator::new(CARGO_MANIFEST_DIR path)` with `sqlx::migrate!()` macro to embed migrations into the binary at compile time
- Add `macros` feature to sqlx workspace dependency (required for `sqlx::migrate!()`)
- Rename all tool names to use underscores instead of dots

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced database initialization with modern macro-based approach for improved reliability.
  * Standardized internal tool identifiers from dot notation to underscore notation for consistency across system, browser, container, and screen tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->